### PR TITLE
Check your work

### DIFF
--- a/pi-to-the-nth.py
+++ b/pi-to-the-nth.py
@@ -10,6 +10,11 @@ several seconds to compute. The number of iterations (and the range) can be
 increase within the code's global variables.
 """
 from decimal import Decimal, getcontext
+from sre_constants import RANGE
+import urllib.request
+import urllib.parse
+import json
+
 
 ITERATIONS = 1000000    # One million iterations provides 18 decimal-points of accuracy
 RANGE_MAX = 20          # TODO: Find if range can be scaled to ITERATIONS
@@ -26,6 +31,7 @@ def main():
                 getcontext().prec = places + 1
                 result = nilakantha(ITERATIONS) 
                 print(result)
+                checkResult(places)
                 break
         # Handle ValueError and pass to error message
         except ValueError:
@@ -44,6 +50,19 @@ def nilakantha(iterations) -> Decimal:
         result += 4 / Decimal(n * (n + 1) * (n + 2) * op)
         op *= -1
     return result
+
+"""
+It's good to check our math against an objective truth. Luckily, Google has accurately calculated pi to a trillion digits
+AND they deliver!
+https://pi.delivery/#apipi_get
+"""
+def checkResult(end):
+    #API Counts 3 as a digit place, so we add one to compensate
+    url = 'https://api.pi.delivery/v1/pi?start=0&numberOfDigits='+str(end+1) 
+    call = urllib.request.urlopen(url)
+    #After making the call, we use the json library to change it into a python compatible object
+    clean = json.loads(call.read().decode('utf-8'))
+    print("Compare to: ",clean['content'])
 
 if __name__ == "__main__":
     main()

--- a/pi-to-the-nth.py
+++ b/pi-to-the-nth.py
@@ -10,7 +10,6 @@ several seconds to compute. The number of iterations (and the range) can be
 increase within the code's global variables.
 """
 from decimal import Decimal, getcontext
-from sre_constants import RANGE
 import urllib.request
 import urllib.parse
 import json

--- a/pi-to-the-nth.py
+++ b/pi-to-the-nth.py
@@ -31,7 +31,7 @@ def main():
                 getcontext().prec = places + 1
                 result = nilakantha(ITERATIONS) 
                 print(result)
-                checkResult(places)
+                checkResult(result, places)
                 break
         # Handle ValueError and pass to error message
         except ValueError:
@@ -56,13 +56,23 @@ It's good to check our math against an objective truth. Luckily, Google has accu
 AND they deliver!
 https://pi.delivery/#apipi_get
 """
-def checkResult(end):
+def checkResult(result, places):
+    truepi = fetchPi(places)
+    print('Compare to: ',truepi)
+    checkpi = str(result).replace('.', '')
+    if truepi == checkpi:
+        print ("✅ It appears the math is correct.")
+    else:
+        print ("❌ The two versions of pi do not align - somebodies math is wrong.")
+
+
+def fetchPi(end):
     #API Counts 3 as a digit place, so we add one to compensate
     url = 'https://api.pi.delivery/v1/pi?start=0&numberOfDigits='+str(end+1) 
     call = urllib.request.urlopen(url)
     #After making the call, we use the json library to change it into a python compatible object
     clean = json.loads(call.read().decode('utf-8'))
-    print("Compare to: ",clean['content'])
+    return clean['content']
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
It is useful to check the work of our calculations against a verified
version of pi.

We could hardcode in a "pi" to check against, but that will become
cumbersome if the program would expand beyond calculating 20 digits.

Luckily, a service exists where we can request a "correct" version of
pi, calculated out to a trillion digits.
https://pi.delivery/

This patchset includes code to fetch pi from the above service, then
compares the two numbers to make sure the math is coming out right. It
requires no libraries beyond the standard, vanilla Python libraries.